### PR TITLE
fix an issue due to timeout

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,3 +1,2 @@
 source("renv/activate.R")
-Sys.setenv("TORCH_INSTALL" = "1")
-Sys.setenv("R_DEFAULT_INTERNET_TIMEOUT" = "3600")
+Sys.setenv("TORCH_INSTALL" = "0")

--- a/Main.R
+++ b/Main.R
@@ -63,6 +63,12 @@ createCohortDefinitionSetFromJobContext <- function(sharedResources, settings) {
 # Module methods -------------------------
 execute <- function(jobContext) {
   library(DeepPatientLevelPrediction)
+  
+  rlang::inform("Install additional files for torch")
+  if(!torch::torch_is_installed()){
+    torch::install_torch(timeout=3600)  
+  }
+  
   rlang::inform("Validating inputs")
   inherits(jobContext, "list")
 


### PR DESCRIPTION
I revised the DeepPatientLevelPredicdtionModule package for fixing an issue due to timeout.

The system environment variable, "R_DEFAULT_INTERNET_TIMEOUT" didn't work for me (even not working outside of the Strategus environment), therefore I added codes for ensuring and installing additional files of the torch package. 

I turn off the autoinstallation through TORCH_INSTALL=0 (it prevents auto-install without timeout parameter) and then the R_DEFAULT_INTERNET_TIMEOUT parameter doesn't need anymore.

Using this, I succeed to run deepPLP in Strategus finally.

if you have another way better than my fix, please ignore this.
(And- I also realized that we have to run this part in the online environment..)